### PR TITLE
fix(bigdata): remove high level API

### DIFF
--- a/spec/bigdata/bigdata.spec.js
+++ b/spec/bigdata/bigdata.spec.js
@@ -45,22 +45,4 @@ describe('bigdata', function() {
             });
         });
     });
-
-    describe('.exportAllData()', function() {
-        it('should return the data for the query', function(done) {
-            client.bigdata.exportAllData({
-                from: 'event',
-                select: [
-                    { value: 'x_event_type' },
-                ]
-            }).then((response) => {
-                expect(response.columns).toBeDefined();
-                expect(response.rows).toBeDefined();
-                done();
-            }).catch((error) => {
-                fail(error);
-                done();
-            })
-        });
-    });
 });

--- a/src/bigdata/bigdata.ts
+++ b/src/bigdata/bigdata.ts
@@ -31,34 +31,4 @@ export class Bigdata {
   streamPage(pageId: string): Promise<StreamPageResponse> {
     return this.client.get(basePath + '/streampage/' + pageId)
   }
-
-  @authenticate
-  exportAllData(query: object): Promise<{ columns: Array<object>, rows: Array<Array<any>> }> {
-    return this.startExport(query).then(({ streamsFirstPages, columns }) => {
-      const allResponsesPromise: Promise<StreamPageResponse[]> = Promise.all(streamsFirstPages.map((pageId) => {
-        return this.streamToTheLastpage(pageId);
-      }));
-
-      return allResponsesPromise.then((allResponses: Array<StreamPageResponse>) => {
-        return {
-          columns: columns,
-          rows: allResponses.reduce(mergeStreamResponse, { rows: [] }).rows
-        };
-      });
-    });
-  }
-
-  @authenticate
-  private streamToTheLastpage(pageId: string): Promise<StreamPageResponse> {
-    return this.streamPage(pageId).then(response => {
-      const nextPage = response.nextPage;
-
-      if (nextPage) {
-        return this.streamToTheLastpage(nextPage)
-            .then((nextResponse) => mergeStreamResponse(response, nextResponse));
-      } else {
-        return response;
-      }
-    });
-  }
 }


### PR DESCRIPTION
The high level API was removed because in real cases, the result array grows out of control and node crashes with "out of memory" errors.

Thus, for the moment, we remove the API.

Maybe in the Future, when `Observable` become a JS standard, we could offer this API.